### PR TITLE
Fixed temperature bulbs to only show temperature capability in Home app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is an OSRAM Lightify plugin for [homebridge](https://github.com/nfarina/homebridge).
 
 ## Setup
-1. Add via `npm install -g homebridge-platform-lightify`
+1. Add via `npm install -g homebridge-platform-lightify-mg`
 2. Add to the homebridge config.json in the `platforms` section
 ```json
 {

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ LightifyPlatform.prototype.refreshTimer = function(timeout) {
     setTimeout(function() {
         var connection = new lightify.lightify(self.config.bridge_ip, self.log);
         self.discover(connection).then(function(data) {
-            self.log.info('Discover Success');
+            self.log.debug('Discover Success');
             data.result.forEach(function(light) {
                 var assc = self.foundAccessories.find(function(assc) {
                     return assc.device && assc.device.mac == light.mac;
@@ -116,7 +116,7 @@ LightifyPlatform.prototype.refreshTimer = function(timeout) {
 LightifyPlatform.prototype.discover = function(connection) {
     var self = this;
     return connection.connect().then(function() {
-        self.log.info('Connected to Lightify Bridge');
+        self.log.debug('Connected to Lightify Bridge');
         //have to discover nodes for light status of group
         return connection.discover();
     }).then(function(data) {
@@ -144,24 +144,24 @@ LightifyPlatform.prototype.discover = function(connection) {
                                 });
                                 if (device && device.online && device.status === 1) {
                                     zone.status = 1;
-                                    self.log.info('Lightify Zone is on');
+                                    self.log.debug('Lightify Zone is on');
                                 }
                                 if(device && lightify.isBrightnessSupported(device.type)) {
                                     zone.isBrightnessSupported = true;
                                     zone.brightness = device.brightness;
-                                    self.log.info('Lightify Zone support brightness, current brightness=[%d]', device.brightness);
+                                    self.log.debug('Lightify Zone support brightness, current brightness=[%d]', device.brightness);
                                 }
                                 if(device && lightify.isColorSupported(device.type)) {
                                     zone.isColorSupported = true;
                                     zone.red = device.red;
                                     zone.green = device.green;
                                     c = device.blue;
-                                    self.log.info('Lightify Zone support color, current red=[%d], green=[%d], blue=[%d]', device.red, zone.green, zone.blue);
+                                    self.log.debug('Lightify Zone support color, current red=[%d], green=[%d], blue=[%d]', device.red, zone.green, zone.blue);
                                 }
                                 if(device && lightify.isTemperatureSupported(device.type)) {
                                     zone.isTemperatureSupported = true;
                                     zone.temperature = device.temperature;
-                                    self.log.info('Lightify Zone support temperature, current temperature=[%d]', device.temperature);
+                                    self.log.debug('Lightify Zone support temperature, current temperature=[%d]', device.temperature);
                                 }
                             }
                             return Promise.resolve();

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var moment = require('moment');
 var util = require('util');
-var lightify = require('node-lightify');
+var lightify = require('node-lightify-mg');
 var Service, Characteristic;
 var Lightbulb;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-lightify-mg",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Lightify plugin for homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [
@@ -19,8 +19,8 @@
   },
   "dependencies": {
     "moment": "^2.21.0",
-    "node-lightify": "^2.1.10",
     "promise": ">=7.1.1",
-    "util": "^0.10.3"
+    "util": "^0.10.3",
+    "node-lightify" : "homespun/node-lightify"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-lightify-mg",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Lightify plugin for homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [
@@ -21,6 +21,6 @@
     "moment": "^2.21.0",
     "promise": ">=7.1.1",
     "util": "^0.10.3",
-    "node-lightify" : "^2.1.10"
+    "node-lightify-mg" : "^2.1.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-lightify-mg",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Lightify plugin for homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "homebridge-platform-lightify",
+  "name": "homebridge-platform-lightify-mg",
   "version": "0.3.0",
   "description": "Lightify plugin for homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
@@ -8,18 +8,19 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/rainlake/homebridge-platform-lightify.git"
+    "url": "git://github.com/mylesgray/homebridge-platform-lightify.git"
   },
   "bugs": {
-    "url": "https://github.com/rainlake/homebridge-platform-lightify/issues"
+    "url": "https://github.com/mylesgray/homebridge-platform-lightify/issues"
   },
   "engines": {
     "node": ">=0.12.0",
     "homebridge": ">=0.2.0"
   },
   "dependencies": {
+    "moment": "^2.21.0",
+    "node-lightify": "^2.1.10",
     "promise": ">=7.1.1",
-    "moment": ">=2.4.0",
-    "node-lightify": ">=2.0.6"
+    "util": "^0.10.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-lightify-mg",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Lightify plugin for homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [
@@ -21,6 +21,6 @@
     "moment": "^2.21.0",
     "promise": ">=7.1.1",
     "util": "^0.10.3",
-    "node-lightify" : "homespun/node-lightify"
+    "node-lightify" : "^2.1.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-lightify-mg",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Lightify plugin for homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [
@@ -21,6 +21,6 @@
     "moment": "^2.21.0",
     "promise": ">=7.1.1",
     "util": "^0.10.3",
-    "node-lightify-mg" : "^2.1.11"
+    "node-lightify-mg" : "^2.1.12"
   }
 }


### PR DESCRIPTION
Before they were showing up with full-colour palate available.

Colour temperature is actually governed by "mired" in Homekit, not hue or Kelvin, as such I have removed saturation and hue capabilities and added the ColorTemperature characteristic to the temperature bulbs as well as the necessary mired conversions to and from Kelvin:

http://cbkmrks.blogspot.co.uk/2013/03/color-temperature-mired-scale-dailey.html

I have also lowered the log level of discovery actions as the log gets extremely verbose and chatty otherwise.

Also resolves part of #11 by removing hard-coded return of a hue "1" for temperature bulbs and instead returning mired value.