### PR TITLE
Add support for contact sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ All other fields are required
 ## About
 This plugin uses the proprietary lightify protocol that the hub uses to commnicate with the lights, rather than the JSON API provided by lightify.
 
-This plugin works with all Lightify products including Tunable White bulbs and outlets.  Sensors are not supported, but are hidden.
+This plugin works with all Lightify products including Tunable White bulbs and outlets. 
+
+Sensors are supported. The sensor will need to be assigned an action in the Lightify app in order to update. The device for which the sensor takes action does not need to be reachable. You can use a spare bulb and have all sensors assigned an action to this bulb.
 
 Please report any issues on github.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ This plugin uses the proprietary lightify protocol that the hub uses to commnica
 
 This plugin works with all Lightify products including Tunable White bulbs and outlets. 
 
-Sensors are supported. The sensor will need to be assigned an action in the Lightify app in order to update. The device for which the sensor takes action does not need to be reachable. You can use a spare bulb and have all sensors assigned an action to this bulb.
+Contact sensors are now supported with a resolution of 2 seconds.
 
 Please report any issues on github.


### PR DESCRIPTION
This fork adds support for the Lightify contact sensor. A motion sensor would work as well but I have none to test with.

-Added function LightifySensor.
-Changed the refresh rate from 30 seconds to 2 seconds. This could probably be faster but I see no need.

Please update the version information per your requirements.